### PR TITLE
Correct card resource mapping

### DIFF
--- a/app/src/main/java/com/example/myapplication/MainActivity.kt
+++ b/app/src/main/java/com/example/myapplication/MainActivity.kt
@@ -83,9 +83,9 @@ class MainActivity : AppCompatActivity() {
 
     private fun getFaceResource(id: Int): Int = when (id) {
         0 -> R.drawable.card_0
-        1 -> R.drawable.card_0
-        2 -> R.drawable.card_1
-        3 -> R.drawable.card_2
+        1 -> R.drawable.card_1
+        2 -> R.drawable.card_2
+        3 -> R.drawable.card_3
         4 -> R.drawable.joker
         else -> R.drawable.card_back
     }

--- a/app/src/test/java/com/example/myapplication/MainActivityTest.kt
+++ b/app/src/test/java/com/example/myapplication/MainActivityTest.kt
@@ -1,0 +1,24 @@
+package com.example.myapplication
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Tests for [MainActivity]'s internal logic.
+ */
+class MainActivityTest {
+    private val activity = MainActivity()
+
+    @Test
+    fun faceResourcesMatchIds() {
+        val method = MainActivity::class.java.getDeclaredMethod("getFaceResource", Int::class.javaPrimitiveType)
+        method.isAccessible = true
+
+        assertEquals(R.drawable.card_0, method.invoke(activity, 0) as Int)
+        assertEquals(R.drawable.card_1, method.invoke(activity, 1) as Int)
+        assertEquals(R.drawable.card_2, method.invoke(activity, 2) as Int)
+        assertEquals(R.drawable.card_3, method.invoke(activity, 3) as Int)
+        assertEquals(R.drawable.joker, method.invoke(activity, 4) as Int)
+    }
+}
+


### PR DESCRIPTION
## Summary
- fix card ID to drawable mapping for MainActivity
- add unit test to verify resource lookup

## Testing
- `./gradlew test` *(fails: Failed to install the following Android SDK packages as some licences have not been accepted)*

------
https://chatgpt.com/codex/tasks/task_e_68a129a2b7f88322b0d3771c06e12e8d